### PR TITLE
follow spatie/valuestore requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "timacdonald/cached-valuestore",
+    "name": "axn/cached-valuestore",
     "description": "An extension of spatie/valuestore with in-memory caching.",
     "keywords": [
         "valuestore",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         }
     },
     "require": {
-        "php": "^7.0 || ^8.0",
+        "php": "^8.0",
         "spatie/valuestore": "^1.0"
     },
     "require-dev": {

--- a/readme.md
+++ b/readme.md
@@ -1,15 +1,21 @@
 # Cached Valuestore
 
-[![Latest Stable Version](https://poser.pugx.org/timacdonald/cached-valuestore/v/stable)](https://packagist.org/packages/timacdonald/cached-valuestore) [![Total Downloads](https://poser.pugx.org/timacdonald/cached-valuestore/downloads)](https://packagist.org/packages/timacdonald/cached-valuestore) [![License](https://poser.pugx.org/timacdonald/cached-valuestore/license)](https://packagist.org/packages/timacdonald/cached-valuestore)
-
 This is an extension of [`spatie/valuestore`](https://github.com/spatie/valuestore) that introduces a local cache in the class. Thanks to Spatie for providing such a great package ecosystem. This is an under appreciated awesome package IMO.
+
+---
+*This is a fork of [Cached Valuestore](https://github.com/timacdonald/cached-valuestore) by [Tim MacDonald](https://github.com/timacdonald) until he finds time to update his. If he can find it between two awesomes features/improvement he brings to [Laravel](https://laravel.com/).*
+
+**A very big thank you to him for all the work he does!**
+
+In order to facilitate the use of this fork we allowed ourselves to put our own vendor rather than having to indicate the location of the repository in the compser.json file. But we left the original namespace.
+---
 
 ## Installation
 
-You can install using [composer](https://getcomposer.org/) from [Packagist](https://packagist.org/packages/timacdonald/cached-valuestore)
+You can install using [composer](https://getcomposer.org/) from [Packagist](https://packagist.org/packages/axn/cached-valuestore)
 
 ```
-$ composer require timacdonald/cached-valuestore
+$ composer require axn/cached-valuestore
 ```
 
 ## Usage

--- a/src/CachedValuestore.php
+++ b/src/CachedValuestore.php
@@ -13,7 +13,7 @@ class CachedValuestore extends Valuestore
      *
      * @return array
      */
-    public function all() : array
+    public function all(): array
     {
         return $this->cache ?? $this->cache = parent::all();
     }
@@ -24,7 +24,7 @@ class CachedValuestore extends Valuestore
      * @param  array $values
      * @return $this
      */
-    protected function setContent(array $values)
+    protected function setContent(array $values): static
     {
         return parent::setContent($this->cache = $values);
     }


### PR DESCRIPTION
Hello,

As [spatie/valuestore](https://github.com/spatie/valuestore) removed support for PHP 7 a long time ago in [#8514412](https://github.com/spatie/valuestore/commit/85144129c7c4611c0e95ef9558cac20fba12cb48), it is possible (necessary?) to do so here as well.

Also, a recent [PR](https://github.com/spatie/valuestore/pull/45) changed the signature of the setContent() method to add the return type.

So, this PR containts two changes: 
- drop PHP 7 support
- add static return type to setContent method

Thanks :)
